### PR TITLE
Added -i --in-place option to nip

### DIFF
--- a/bin/nip
+++ b/bin/nip
@@ -13,6 +13,7 @@ program
   .option('-s, --line-splitter [splitter]', 'line spliter regex or string', '/\\r?\\n/')
   .option('-n, --line-joiner [joiner]', 'string to join lines together with', '\n')
   .option('-c, --col-splitter [spliter]', 'column splitter regex or string', '\\s+')
+  .option('-i, --in-place', 'write the output in the input file')
   ;
 
 program.on('--help', function() {
@@ -72,6 +73,7 @@ nip({
   lineSeparatorRegex: regexize(program.lineSplitter),
   colSeparatorRegex: regexize(program.colSplitter),
   lineSeparator: program.lineJoiner,
-  firstLineOnly: program.firstLineOnly
+  firstLineOnly: program.firstLineOnly,
+  inPlace: program.inPlace
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,7 @@ function nip(options) {
       if (options.inPlace && filename != "-") {
         options.outStream.end();
         var fs = require('fs');
-        fs.rename(filename +".nip", filename);
+        fs.renameSync(filename +".nip", filename);
       }
 
       processNextFile();

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,12 @@ function nip(options) {
     if (fileIndex === 0) { context.emit('start'); }
     context.emit('fileStart');
     var processer = options.firstLineOnly ? processAsBuffer : processAsStream;
+
+    if (options.inPlace && filename != "-") {
+      var fs = require('fs');
+      options.outStream = fs.createWriteStream(filename+".nip");
+    }
+
     processer({
       filename: filename,
       context: context,
@@ -54,6 +60,13 @@ function nip(options) {
     }, function() {
       context.emit('fileEnd');
       fileIndex++;
+
+      if (options.inPlace && filename != "-") {
+        options.outStream.end();
+        var fs = require('fs');
+        fs.rename(filename +".nip", filename);
+      }
+
       processNextFile();
     });
   }

--- a/test/simple/api.js
+++ b/test/simple/api.js
@@ -163,6 +163,29 @@ describe('simple manipulation', function() {
         process.stdin.emit('end');
       });
 
+      it('works with --in-place option', function (done) {
+        var fn = function (line, index, cols, lines) {
+          return lines.map(function (line) {
+            return line.toUpperCase();
+          }).join('\n');
+        };
+
+        nip({
+          files: [fileLocation],
+          callback: fn,
+          lineSeparatorRegex: /\n/,
+          lineSeparator: '\n',
+          colSeparatorRegex: /\s+/g,
+          firstLineOnly: true,
+          inPlace: true,
+          doneCallback: function () {
+            var inPlaceContents = fs.readFileSync(fileLocation).toString();
+            assert.equal(inPlaceContents, fileContents.toUpperCase());
+            fs.writeFileSync(fileLocation, fileContents); // restore the content of fileLocation
+            done();
+          }
+        });
+      });
     });
 
     describe('when using the buffer technique', function() {


### PR DESCRIPTION
I wanted an easy way to output the changes to the same file.

For example, I use it to replace __FILE__ and __LINE__ in javascript code:
example.js:
console.log("__FILE_LINE__");

I can preprocess the file with this command:
nip -i 'function(line, i) { return line.indexOf("__FILE_LINE__") >= 0 ? line.replace("__FILE_LINE__",this.filename+":"+i) : line; }' example.js

