### PR TITLE
fix: program.file to file string

### DIFF
--- a/bin/nip
+++ b/bin/nip
@@ -8,7 +8,7 @@ var program = require('commander');
 program
   .version(require('../package.json').version)
   .usage('[js-code] <file ...>')
-  .option('-f, --file', 'javascript file containing the js-code')
+  .option('-f, --file <js>', 'javascript file containing the js-code')
   .option('-1, --first-line-only', 'process whole file at once, not line by line')
   .option('-s, --line-splitter [splitter]', 'line spliter regex or string', '/\\r?\\n/')
   .option('-n, --line-joiner [joiner]', 'string to join lines together with', '\n')


### PR DESCRIPTION
According to [Commander.js doc](https://github.com/tj/commander.js#common-option-types-boolean-and-value).

> an option which takes its value from the following argument (declared with angle brackets like --expect **<value>**)

It should use angle brackets to declare `file` option, otherwise, [`program.file`](https://github.com/kolodny/nip/blob/3d2cfe6e2501e1dc67fa1a5e8900676965532df5/bin/nip#L36) is `true` and cause error. @kolodny 🤣